### PR TITLE
Fix CLI args

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This builds two versions of the emulator:
 ## Playing
 
 ```
-usage: gbemu [--debug] [--trace] [--silent] [--exit-on-infinite-jr] [--print-serial-output] <rom_file>
+usage: gbemu <rom_file> [--debug] [--trace] [--silent] [--exit-on-infinite-jr] [--print-serial-output]
 
 arguments:
   --debug                   Enable the debugger

--- a/platforms/cli/cli.h
+++ b/platforms/cli/cli.h
@@ -21,14 +21,13 @@ CliOptions get_cli_options(int argc, char* argv[]) {
 
     for (std::string& flag : flags) {
         if (flag == "--debug") { cliOptions.options.debugger = true; }
-        if (flag == "--trace") { cliOptions.options.trace = true; }
-        if (flag == "--silent") { cliOptions.options.disable_logs = true; }
-        if (flag == "--headless") { cliOptions.options.headless = true; }
-        if (flag == "--whole-framebuffer") { cliOptions.options.show_full_framebuffer = true; }
-        if (flag == "--exit-on-infinite-jr") { cliOptions.options.exit_on_infinite_jr = true; }
-        if (flag == "--print-serial") { cliOptions.options.print_serial = true; }
-
-        fatal_error("Unknown flag: %s", flag.c_str());
+        else if (flag == "--trace") { cliOptions.options.trace = true; }
+        else if (flag == "--silent") { cliOptions.options.disable_logs = true; }
+        else if (flag == "--headless") { cliOptions.options.headless = true; }
+        else if (flag == "--whole-framebuffer") { cliOptions.options.show_full_framebuffer = true; }
+        else if (flag == "--exit-on-infinite-jr") { cliOptions.options.exit_on_infinite_jr = true; }
+        else if (flag == "--print-serial") { cliOptions.options.print_serial = true; }
+        else { fatal_error("Unknown flag: %s", flag.c_str()); }
     }
 
     return cliOptions;


### PR DESCRIPTION
Entering valid CLI arguments always throws a fatal error. Also, the README states that the ROM file must be entered after the other arguments but it actually must be entered first.
```
./build/gbemu ../DrMario.gb --trace
Fatal error @ CliOptions get_cli_options(int, char**) (line 31)
Unknown flag: --trace
```

Fixed the CLI options parser so that each argument is iterated and parsed correctly.